### PR TITLE
Change fastcgi_pass value of domain configuration files to match the lis...

### DIFF
--- a/domain.sh
+++ b/domain.sh
@@ -159,7 +159,7 @@ server {
         # Pass PHP scripts to PHP-FPM
         location ~ \.php$ {
             try_files \$uri =403;
-            fastcgi_pass unix:/var/run/php5-fpm-$DOMAIN_OWNER.sock;
+            fastcgi_pass unix:/var/run/php5-fpm-www-data.sock;
             include fastcgi_params;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
@@ -217,7 +217,7 @@ server {
 
         location ~ \.php$ {
             try_files \$uri =403;
-            fastcgi_pass unix:/var/run/php5-fpm-$DOMAIN_OWNER.sock;
+            fastcgi_pass unix:/var/run/php5-fpm-www-data.sock;
             include fastcgi_params;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;


### PR DESCRIPTION
...ten directive of $php_fpm_conf
- Resolves 502 Bad Gateway error with PHP 5.5.12
