### PR TITLE
Added ADMIN_EMAIL & ROOT_LOGIN options in options.conf

### DIFF
--- a/options.conf
+++ b/options.conf
@@ -8,6 +8,9 @@ SSHD_PORT=22
 # Set an admin email account to be used for various system notifications and alerts
 ADMIN_EMAIL="admin@yourdomain.com"
 
+# Choose whether you want to maintain 'root login' or not. Options = yes|no
+ROOT_LOGIN=no
+
 # Configure /etc/apt/sources.list to use redirector/geolocation mirrors
 # Improves package download speeds. Options = yes|no
 CONFIGURE_APT=no

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,9 @@ function basic_server_setup {
 
     # Reconfigure sshd - change port and disable root login
     sed -i 's/^Port [0-9]*/Port '${SSHD_PORT}'/' /etc/ssh/sshd_config
-    sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+	if  [ $ROOT_LOGIN = "no" ]; then
+    	sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+	fi;
     service ssh reload
 
     # Set hostname and FQDN


### PR DESCRIPTION
To be used for email notifications/alerts. Specifically, other bash scripts could use this variable to notify the admin for backups, firewall intrusion attempts and so on.
