### PR TITLE
Updates Apache.conf to 2.4 defaults, adressing https://github.com/Mins/TuxLite/issues/46

### DIFF
--- a/config/apache2.conf
+++ b/config/apache2.conf
@@ -86,7 +86,7 @@
 #
 # The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
 #
-LockFile ${APACHE_LOCK_DIR}/accept.lock
+Mutex file:${APACHE_LOCK_DIR} default
 
 #
 # PidFile: The file in which the server should record its process
@@ -121,20 +121,20 @@ KeepAliveTimeout 5
 
 ##
 ## Server-Pool Size Regulation (MPM specific)
-## 
+##
 
 # prefork MPM
 # StartServers: number of server processes to start
 # MinSpareServers: minimum number of server processes which are kept spare
 # MaxSpareServers: maximum number of server processes which are kept spare
-# MaxClients: maximum number of server processes allowed to start
-# MaxRequestsPerChild: maximum number of requests a server process serves
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# MaxConnectionsPerChild: maximum number of requests a server process serves
 <IfModule mpm_prefork_module>
     StartServers          5
     MinSpareServers       5
     MaxSpareServers      10
-    MaxClients          150
-    MaxRequestsPerChild   0
+    MaxRequestWorkers    150
+    MaxConnectionsPerChild   0
 </IfModule>
 
 # worker MPM
@@ -145,16 +145,16 @@ KeepAliveTimeout 5
 #              graceful restart. ThreadLimit can only be changed by stopping
 #              and starting Apache.
 # ThreadsPerChild: constant number of worker threads in each server process
-# MaxClients: maximum number of simultaneous client connections
-# MaxRequestsPerChild: maximum number of requests a server process serves
+# MaxRequestWorkers: maximum number of simultaneous client connections
+# MaxConnectionsPerChild: maximum number of requests a server process serves
 <IfModule mpm_worker_module>
     StartServers          2
     MinSpareThreads      25
-    MaxSpareThreads      75 
+    MaxSpareThreads      75
     ThreadLimit          64
     ThreadsPerChild      25
-    MaxClients          150
-    MaxRequestsPerChild   0
+    MaxRequestWorkers    150
+    MaxConnectionsPerChild   0
 </IfModule>
 
 # event MPM
@@ -162,16 +162,16 @@ KeepAliveTimeout 5
 # MinSpareThreads: minimum number of worker threads which are kept spare
 # MaxSpareThreads: maximum number of worker threads which are kept spare
 # ThreadsPerChild: constant number of worker threads in each server process
-# MaxClients: maximum number of simultaneous client connections
-# MaxRequestsPerChild: maximum number of requests a server process serves
+# MaxRequestWorkers: maximum number of simultaneous client connections
+# MaxConnectionsPerChild: maximum number of requests a server process serves
 <IfModule mpm_event_module>
     StartServers          1
     MinSpareThreads       2
-    MaxSpareThreads       5 
+    MaxSpareThreads       5
     ThreadLimit           20
     ThreadsPerChild       20
-    MaxClients            60
-    MaxRequestsPerChild   5000
+    MaxRequestWorkers     60
+    MaxConnectionsPerChild   5000
 </IfModule>
 
 # These need to be set in /etc/apache2/envvars
@@ -187,21 +187,19 @@ Group ${APACHE_RUN_GROUP}
 AccessFileName .htaccess
 
 #
-# The following lines prevent .htaccess and .htpasswd files from being 
-# viewed by Web clients. 
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
 #
 <Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
+    Require all denied
     Satisfy all
 </Files>
 
 # TuxLite. Better to put this block here compared to Debian's default
 <Directory />
-    Options -Indexes FollowSymLinks
+    Options Indexes FollowSymLinks
     AllowOverride All
-    Order allow,deny
-    allow from all
+    Require all granted
 </Directory>
 
 #
@@ -270,8 +268,7 @@ LogFormat "%{User-agent}i" agent
 # see the comments above for details.
 
 # Include generic snippets of statements
-Include conf.d/
+IncludeOptional conf-enabled/*.conf
 
 # Include the virtual host configurations:
-Include sites-enabled/
-
+IncludeOptional sites-enabled/*.conf

--- a/config/apache2.conf
+++ b/config/apache2.conf
@@ -268,7 +268,7 @@ LogFormat "%{User-agent}i" agent
 # see the comments above for details.
 
 # Include generic snippets of statements
-IncludeOptional conf-enabled/*.conf
+IncludeOptional conf-enabled/
 
 # Include the virtual host configurations:
-IncludeOptional sites-enabled/*.conf
+IncludeOptional sites-enabled/


### PR DESCRIPTION
I wanted to use TuxLite to provision a fresh install of Ubuntu 14.04 LTS but found that, as described in https://github.com/Mins/TuxLite/issues/46, installation fails with errors from Apache.

I went through the Apache 2.2> 2.4 upgrade checklist at: http://httpd.apache.org/docs/2.4/upgrading.html and updated the default conf accordingly.

After these changes the script was run in a clean install of Ubuntu 14.04 LTS and completed successfully. 

Please note, I have _not_ tested these changes against any other distro.
