### PR TITLE
Remove insecure SSL protocols

### DIFF
--- a/domain.sh
+++ b/domain.sh
@@ -216,7 +216,7 @@ server {
 
         ssl_session_timeout 5m;
 
-        ssl_protocols SSLv2 SSLv3 TLSv1;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers HIGH:!aNULL:!MD5;
         ssl_prefer_server_ciphers on;
 
@@ -291,6 +291,7 @@ EOF
     SSLEngine on
     SSLCertificateFile    /etc/ssl/localcerts/webserver.pem
     SSLCertificateKeyFile /etc/ssl/localcerts/webserver.key
+    SSLProtocol           all -SSLv3 -SSLv2
 
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars


### PR DESCRIPTION
SSLv2 has [several vulnerabilities](http://www.rapid7.com/db/vulnerabilities/sslv2-and-up-enabled) and SSLv3 is vulnerable to POODLE.
